### PR TITLE
Update HTTP.pm

### DIFF
--- a/Slim/Web/HTTP.pm
+++ b/Slim/Web/HTTP.pm
@@ -829,8 +829,8 @@ sub processURL {
 						$agent = 'Winamp';
 					}
 
-					if ($address =~ m/alexa/i) {
-						$client->name( "Amazon Echo" );
+					if ( $address =~ m/^alexa|^amazon|^echo/i ) {
+						$client->name( 'AlexaPlayer' );
 					} else {
 						$client->name( $agent . ' ' . string('FROM') . ' ' . $address );
 					}


### PR DESCRIPTION
Changes the name of a /stream.mp3 network client/player to 'AlexaPlayer' instead of the current 'Axios from Alexa' (note that Axios is the UserAgent used by the MediaServer skill). This only happens if the player name starts with any of Alexa, Amazon or Echo so existing non-Alexa clients are not affected by this change.